### PR TITLE
ES2015 classes and prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   },
   "author": "James K Nelson <james@jamesknelson.com>",
   "license": "MIT",
+  "dependencies": {
+    "prop-types": "^15.5.0"
+  },
   "peerDependencies": {
     "react": "^15.3.2",
     "junctions": "^0.3.0"

--- a/source/HistoryContext.js
+++ b/source/HistoryContext.js
@@ -1,25 +1,25 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
+export default class HistoryContext
+  extends React.Component {
 
-export default React.createClass({
-  displayName: 'HistoryContext',
-
-  propTypes: {
-    history: React.PropTypes.object.isRequired,
-    children: React.PropTypes.element.isRequired,
-  },
-
-  childContextTypes: {
-    history: React.PropTypes.object
-  },
-
-  getChildContext: function() {
+  getChildContext() {
     return {
       history: this.props.history
     }
-  },
+  }
 
   render() {
     return this.props.children
   }
-})
+}
+
+HistoryContext.propTypes = {
+  history: PropTypes.object.isRequired,
+  children: PropTypes.element.isRequired,
+}
+
+HistoryContext.childContextTypes = {
+  history: PropTypes.object
+}

--- a/source/Link.js
+++ b/source/Link.js
@@ -17,8 +17,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 
-import React from 'react'
-
+import React from 'react';
+import PropTypes from 'prop-types';
 
 function isLeftClickEvent(event) {
   return event.button === 0
@@ -28,23 +28,10 @@ function isModifiedEvent(event) {
   return !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey)
 }
 
+export default class Link
+  extends React.Component {
 
-export default React.createClass({
-  displayName: 'Link',
-
-  contextTypes: {
-    history: React.PropTypes.object,
-  },
-
-  propTypes: {
-    history: React.PropTypes.object,
-
-    to: React.PropTypes.object.isRequired,
-    onClick: React.PropTypes.func,
-    target: React.PropTypes.string
-  },
-
-  handleClick: function(event) {
+  handleClick(event) {
     if (this.props.onClick) {
       this.props.onClick(event)
     }
@@ -71,7 +58,7 @@ export default React.createClass({
     event.preventDefault()
 
     history.push(this.props.to)
-  },
+  }
 
   render() {
     var props = {}
@@ -90,4 +77,16 @@ export default React.createClass({
 
     return React.createElement('a', props)
   }
-})
+}
+
+Link.contextTypes = {
+  history: PropTypes.object
+}
+
+Link.propTypes = {
+  history: PropTypes.object,
+
+  to: PropTypes.object.isRequired,
+  onClick: PropTypes.func,
+  target: PropTypes.string
+}

--- a/source/Link.js
+++ b/source/Link.js
@@ -17,8 +17,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from 'react'
+import PropTypes from 'prop-types'
 
 function isLeftClickEvent(event) {
   return event.button === 0

--- a/source/Router.js
+++ b/source/Router.js
@@ -1,47 +1,32 @@
-import React, { Component, PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import { createConverter, locationsEqual } from 'junctions'
 import HistoryContext from './HistoryContext'
 
-
-export default React.createClass({
-  displayName: 'Router',
-
-  propTypes: {
-    baseLocation: PropTypes.shape({
-      pathname: PropTypes.string,
-      search: PropTypes.string,
-      state: PropTypes.object,
-    }),
-    history: PropTypes.object.isRequired,
-    junction: PropTypes.object.isRequired,
-    render: PropTypes.oneOfType([PropTypes.func, PropTypes.instanceOf(Component), PropTypes.element]).isRequired,
-  },
-
-  childContextTypes: {
-    history: PropTypes.object,
-  },
+export default class Router
+  extends React.Component {
 
   getChildContext() {
     return {
       history: this.props.history,
     }
-  },
+  }
 
   componentWillMount() {
     this.converter = createConverter(this.props.junction, this.props.baseLocation)
     this.handleLocationChange(this.props.history.location)
-  },
+  }
 
   componentDidMount() {
     this.unlisten = this.props.history.listen(this.handleLocationChange)
-  },
+  }
 
   componentWillUnmount() {
     if (this.unlisten) {
       this.unlisten()
-      this.unlisten = null  
+      this.unlisten = null
     }
-  },
+  }
 
   componentWillReceiveProps(nextProps) {
     const prevBase = this.props.baseLocation
@@ -51,9 +36,9 @@ export default React.createClass({
       (!prevBase && nextBase) ||
       (nextBase && !prevBase) ||
       (nextBase && prevBase &&
-          nextBase.pathname != prevBase.pathname &&
-          nextBase.search != prevBase.search &&
-          nextBase.state != prevBase.state
+        nextBase.pathname != prevBase.pathname &&
+        nextBase.search != prevBase.search &&
+        nextBase.state != prevBase.state
       )
 
     // Don't recreate the converter unless we need to, as it can be an expensive operation,
@@ -61,7 +46,7 @@ export default React.createClass({
     if (baseChanged || nextProps.junction != this.props.junction) {
       this.converter = createConverter(nextProps.junction, nextProps.baseLocation)
     }
-  },
+  }
 
   handleLocationChange(location) {
     const route = this.converter.route(location)
@@ -72,7 +57,7 @@ export default React.createClass({
     }
 
     this.setState({ route })
-  },
+  }
 
   render() {
     const renderProps = {
@@ -82,7 +67,7 @@ export default React.createClass({
     }
 
     let content
-    if (this.props.render instanceof Component) {
+    if (this.props.render instanceof React.Component) {
       content = React.createElement(this.props.render, renderProps)
     }
     else if (typeof this.props.render == 'function') {
@@ -92,6 +77,21 @@ export default React.createClass({
       content = React.cloneElement(this.props.render, renderProps)
     }
 
-    return React.createElement(HistoryContext, {history: this.props.history}, content)
-  },
-})
+    return React.createElement(HistoryContext, { history: this.props.history }, content)
+  }
+}
+
+Router.propTypes = {
+  baseLocation: PropTypes.shape({
+    pathname: PropTypes.string,
+    search: PropTypes.string,
+    state: PropTypes.object,
+  }),
+  history: PropTypes.object.isRequired,
+  junction: PropTypes.object.isRequired,
+  render: PropTypes.oneOfType([PropTypes.func, PropTypes.instanceOf(React.Component), PropTypes.element]).isRequired
+}
+
+Router.childContextTypes = {
+  history: PropTypes.object
+}


### PR DESCRIPTION
I was getting warnings while using the 'react-junctions' package because of the following two reasons:
- `React.createClass` is made obsolete, ES2015 classes are preferred
- Using `PropTypes` from the main 'react' package is discouraged, instead the 'prop-types' package should be used.

This Pull Request addresses both of these issues.